### PR TITLE
docker: document single dockerfile

### DIFF
--- a/docs/quickstart/build_setup.md
+++ b/docs/quickstart/build_setup.md
@@ -7,7 +7,7 @@ The CLI supports two deployment modes: local development and containerized *semi
 Before going on, let's move into the project directory:
 
 ``` console
-$ cd december-release
+$ cd january-release
 ```
 
 **Known issues**:
@@ -21,7 +21,7 @@ The error message is not intuitive: it is not because no flavour was specified t
 
 ### Build the docker images
 
-We use the `build` command with the `--containers` flag to build the images specified in the `december-release/docker-compose.full.yml`.
+We use the `build` command with the `--containers` flag to build the images specified in the `january-release/docker-compose.full.yml`.
 In addition, we need to add ``--pre`` in order to allow `pipenv` to install alpha releases, since many InvenioRDM packages are now in this phase. Be patient, the docker images might take some time to build.
 
 ``` console
@@ -29,12 +29,11 @@ In addition, we need to add ``--pre`` in order to allow `pipenv` to install alph
 Building RDM application...
 Locking dependencies...
 Bootstrapping server...
-Building base docker image...
 Building applications docker image...
 Creating services...
 ```
 
-As a result, six images (December-Release, Nginx, Redis, PostgreSQL, RabbitMQ and Elasticsearch) have been built.
+As a result, six images (january-release, Nginx, Redis, PostgreSQL, RabbitMQ and Elasticsearch) have been built.
 
 ### Setup the DB, ES and others
 

--- a/docs/quickstart/config.md
+++ b/docs/quickstart/config.md
@@ -33,11 +33,11 @@ When we set `RECORDS_PERMISSIONS_RECORD_POLICY = MyRecordPermissionPolicy`, we a
 
 That's it configuration-wise. If we try to create a record through the API, your instance will check if you are a super user before allowing you. The same approach to configuration holds for any other setting you would like to override. Now we must stop the current instance, rebuild the application image and re-start it to see our changes take effect.
 
-You can run the same `build` command. If you are in a hurry, you can skip locking dependencies and building the base image.
+You can run the same `build` command. If you are in a hurry, you can skip locking dependencies.
 
 ``` console
 (your-virtualenv)$ invenio-cli server --containers --stop
-(your-virtualenv)$ invenio-cli build --pre --containers [--skip-base --skip-lock]
+(your-virtualenv)$ invenio-cli build --pre --containers [--skip-lock]
 (your-virtualenv)$ invenio-cli server --containers --start
 ```
 
@@ -93,7 +93,7 @@ Note that this user will have ID 2.
 # TODO Wait until invenio-oauthclient REST only is integrated
 ```
 
-Afterwards we can test if the new permissions are working correctly. 
+Afterwards we can test if the new permissions are working correctly.
 
 ``` console
 $ curl -k -XPOST -H "Authorization:Bearer sHHq1K9y7a2v5doKDRSFmSFOxa1tZDHFcbs31npaxm1sFEt27yomLMt0ynkl" -H "Content-Type: application/json" https://localhost/api/records/ -d '

--- a/docs/quickstart/init.md
+++ b/docs/quickstart/init.md
@@ -69,7 +69,6 @@ drwxr-xr-x 4 youruser youruser 4096 Dec 19 13:45 docker/
 -rw-r--r-- 1 youruser youruser 2932 Dec 19 13:45 docker-compose.full.yml
 -rw-r--r-- 1 youruser youruser  943 Dec 19 13:45 docker-compose.yml
 -rw-r--r-- 1 youruser youruser 1152 Dec 19 13:45 Dockerfile
--rw-r--r-- 1 youruser youruser  703 Dec 19 13:45 Dockerfile.base
 -rw-r--r-- 1 youruser youruser 2665 Dec 19 13:45 docker-services.yml
 -rw-r--r-- 1 youruser youruser 2018 Dec 19 13:45 .invenio
 -rw-r--r-- 1 youruser youruser 1504 Dec 19 13:45 invenio.cfg


### PR DESCRIPTION
Let's use your repository as the temporary official one and start updating the docs there. This way we don't forget to update the docs at release time and we don't interfere with the wiki that others may be looking at during the month.

